### PR TITLE
ユーザーモデルの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap-sass', '3.3.7'
+gem 'bcrypt', '3.1.12'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.4.10)
       execjs
+    bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.4.1)
       msgpack (~> 1.0)
@@ -199,6 +200,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (= 3.1.12)
   bootsnap (>= 1.1.0)
   bootstrap-sass (= 3.3.7)
   byebug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,10 @@
+class User < ApplicationRecord
+  before_save {self.email = email.downcase }
+  validates :name, presence: true, length: { maximum: 50}
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, length: { maximum: 255},
+            format: { with: VALID_EMAIL_REGEX },
+            uniqueness: true
+  has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }
+end

--- a/db/migrate/20190306145959_create_users.rb
+++ b/db/migrate/20190306145959_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190306154433_add_index_to_users_email.rb
+++ b/db/migrate/20190306154433_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20190306155409_add_password_digest_to_users.rb
+++ b/db/migrate/20190306155409_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_03_06_155409) do
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "password_digest"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 目的
ユーザー新規登録を実装するためのモデルを作成すること。

## やったこと
- Userモデルの新規作成
- DBのマイグレーション
- name,emailに存在性(presence)の実装
- nameを30文字、emailsを255文字の長さに設定
- emailに正規表現の実装
- emailに一意性(uniqueness)の実装
- emailの一意性を矯正するためのマイグレーションを追加
- before_saveというコールバックを実装し、ユーザーをデータベースに保存する前にemail属性を強制的に小文字に変換するようにした
- has_secure_passwordでセキュアなパスワードを追加
- bcryptという、has_secure_passwordを使ってパスワードをハッシュ化するために必要なgemを追加
- usersテーブルにpassword_digestのカラムを追加、マイグレーション
- passwordの最小文字数を設定
- サンプルデータとして、ユーザーデータを1つrails cにて作成（name: "Michael Hartl", email: "mhartl@example.com",password: "foobar", password_confirmation: "foobar")