### PR TITLE
ユーザー登録フォームの作成と実際のユーザー登録

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -155,3 +155,31 @@ aside {
 .gravatar_edit {
   margin-top: 15px;
 }
+
+/* forms */
+
+input, textarea, select, .uneditable-input {
+  border: 1px solid #bbb;
+  width: 100%;
+  margin-bottom: 15px;
+  @include box_sizing;
+}
+
+input {
+  height: auto !important;
+}
+
+#error_explanation {
+  color: red;
+  ul {
+    color: red;
+    margin: 0 0 30px 0;
+  }
+}
+
+.field_with_errors {
+  @extend .has-error;
+  .form-control {
+    color: $state-danger-text;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,25 @@
 class UsersController < ApplicationController
   def new
+    @user = User.new
   end
 
   def show
     @user = User.find(params[:id])
   end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      flash[:success] = "Welcome to the ペンパチズム!"
+      redirect_to @user
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password, :password_confimation)
+    end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,9 @@
   <body>
   <%= render 'layouts/header' %>
     <div class="container">
+      <% flash.each do |message_type, message| %>
+      <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>
       <%= debug(params) if Rails.env.development? %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,2 +1,23 @@
+<% provide(:title, 'Sign up') %>
 <h1>Sign up</h1>
-<p>This will be a signup page for new users.</p>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user) do |f| %>
+      <%= render 'shared/error_messages' %>
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control' %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password,class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Create my account", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   get '/help', to: 'static_pages#help'
   get '/about', to: 'static_pages#about'
   get '/contact', to: 'static_pages#contact'
-  get 'signup', to: 'users#new'
+  get '/signup', to: 'users#new'
   resources :users
 end


### PR DESCRIPTION
## 目的
/signupにて、ユーザー登録フォームを完成させ、実際に1人ユーザーを新規登録して、対象のユーザー画面に登録成功のメッセージを表示させる。

## やったこと
- usersのnewビューにユーザー登録フォームのhtmlを追加
- stylesheetsのcustom.scssにユーザー登録フォームのCSSを追加
- userコントローラのcreateアクションに、ストロングパラメータのprivateメソッドとユーザー登録成功/失敗時の対応を追加
- usersのnewビューに、ユーザー登録失敗時に表示されるエラーメッセージを追加
- viewsにsharedという、フォーム送信時にエラーメッセージを表示するためのパーシャルのディレクトリを作成、コード実装
- stylesheetsのcustom.scssにエラーメッセージにスタイルを付与するためのCSSを追加
- userコントローラのcreateアクションに、作成したユーザー個人のページに飛ぶためのredirectを追加
- userコントローラのcreateアクションに、、ユーザー登録完了後に成功のメッセージが表示されるようflash変数を追加
- flash変数の内容をviews/layouts/application.html.erbに追加
- 実際にユーザー登録する前に、bundle exec rake db:migrate:resetを実行
- 「Rails Tutorial」というユーザーの新規登録に成功