### PR TITLE
ヘッダーとフッターのhtmlのリンク先を修正

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,8 +5,8 @@
   </small>
   <nav>
     <ul>
-      <li><%= link_to "About",   'about_path' %></li>
-      <li><%= link_to "Contact", 'contact_path' %></li>
+      <li><%= link_to "About", about_path %></li>
+      <li><%= link_to "Contact", contact_path %></li>
       <li><a href="http://news.railstutorial.org/">News</a></li>
     </ul>
   </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,8 +3,8 @@
     <%= link_to "ペンパチズム", '#', id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home",   'root_path' %></li>
-        <li><%= link_to "Help",   'help_path' %></li>
+        <li><%= link_to "Home", root_path %></li>
+        <li><%= link_to "Help", help_path %></li>
         <li><%= link_to "Log in", '#' %></li>
       </ul>
     </nav>


### PR DESCRIPTION
## 目的
ホーム画面でhome,help,about,contactの各ボタンをクリックして、各々のリンク先ページに遷移できるようにする。

## やったこと
- headerとfooterのhtmlのlink_toで指定しているリンク先のシングルクォーテーションを外した