### PR TITLE
ホーム画面左上のボタンでホーム遷移と、ホーム画面中央の新規登録ボタンの遷移の設定

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="navbar navbar-fixed-top navbar-inverse">
   <div class="container">
-    <%= link_to "ペンパチズム", '#', id: "logo" %>
+    <%= link_to "ペンパチズム", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
         <li><%= link_to "Home", root_path %></li>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -3,7 +3,7 @@
 
   <h2>ペンパチのためのラケット/ラバー投稿サイト</h2>
 
-  <%= link_to "Sign up now!", 'signup_path', class: "btn btn-lg btn-primary" %>
+  <%= link_to "新規登録", signup_path, class: "btn btn-lg btn-primary" %>
 </div>
 
 <%= link_to image_tag("rails.png", alt: "Rails logo"),


### PR DESCRIPTION
## 目的
- ホーム画面左上の「ペンパチズム」をクリックするとホーム画面に遷移する。
- ホーム画面中央の「新規登録」をクリックすると、ユーザー登録の画面に遷移する。

## やったこと
- headerのリンク先を修正
- static_pagesのhome/htmlのリンク先を修正