### PR TITLE
ログイン機能の実装の途中まで作成

### DIFF
--- a/app/models/login_user.rb
+++ b/app/models/login_user.rb
@@ -1,0 +1,6 @@
+class LoginUser < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/models/racket.rb
+++ b/app/models/racket.rb
@@ -1,0 +1,2 @@
+class Racket < ApplicationRecord
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,14 @@
     <%= link_to "ペンパチズム", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Help", help_path %></li>
-        <li><%= link_to "Log in", '#' %></li>
+        <% if login_user_signed_in? %>
+          <li><%= link_to "ログアウト", destroy_login_user_session, method: :delete %></li>
+          <li><%= link_to "トップ", rackets_path %></li>
+          <li><%= link_to "投稿画面へ", new_rackets_path %></li>
+        <% else %>
+          <li><%= link_to "ログイン", new_login_user_session_path, class: 'post' %></li>
+          <li><%= link_to "新規登録", new_login_user_registration_path, class: 'post' %></li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :login_users
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root 'static_pages#home'

--- a/db/migrate/20190310183237_devise_create_login_users.rb
+++ b/db/migrate/20190310183237_devise_create_login_users.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateLoginUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :login_users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :login_users, :email,                unique: true
+    add_index :login_users, :reset_password_token, unique: true
+    # add_index :login_users, :confirmation_token,   unique: true
+    # add_index :login_users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20190310184245_create_rackets.rb
+++ b/db/migrate/20190310184245_create_rackets.rb
@@ -1,0 +1,10 @@
+class CreateRackets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rackets do |t|
+      t.string :name
+      t.integer :price
+      t.integer :login_user_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_10_155933) do
+ActiveRecord::Schema.define(version: 2019_03_10_184245) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -36,6 +36,26 @@ ActiveRecord::Schema.define(version: 2019_03_10_155933) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "login_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_login_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_login_users_on_reset_password_token", unique: true
+  end
+
+  create_table "rackets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "price"
+    t.integer "login_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,5 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
 AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?
+
+Racket.create(name: "バルサ", price: 5000, login_user_id: 1)
+Racket.create(name: "ブラックバルサ", price: 6000, login_user_id: 1)
+Racket.create(name: "アコースティックC", price: 10000, login_user_id: 1)

--- a/test/fixtures/login_users.yml
+++ b/test/fixtures/login_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/rackets.yml
+++ b/test/fixtures/rackets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/login_user_test.rb
+++ b/test/models/login_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LoginUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/racket_test.rb
+++ b/test/models/racket_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RacketTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 目的
ログイン機能を実装するために必要なモデルを作成する

## やったこと
- devise用のlogin_userモデルの追加(すでにuserモデルはあるので、重複しないように名前を変更した)
　### userとlogin_userを間違えないように注意！
- ナビバーにログイン時と非ログイン時に表示される画面を別々に追加
- racketモデルの追加
- id1に対し、3つのデータをseedに追加
※login_user,racketモデルどちらもrake db:migrate済み。racketはseedも完了済み。

次回はracketのルーティング設定から始める。